### PR TITLE
Update nodejs-lts to 8.9.4 release

### DIFF
--- a/nodejs-lts/legal/VERIFICATION.txt
+++ b/nodejs-lts/legal/VERIFICATION.txt
@@ -4,12 +4,12 @@ in verifying that this package's contents are trustworthy.
 
 1.  Download the installer:
 
-    x32: https://nodejs.org/dist/v8.9.3/node-v8.9.3-x86.msi
-    x64: https://nodejs.org/dist/v8.9.3/node-v8.9.3-x64.msi
+    x32: https://nodejs.org/dist/v8.9.4/node-v8.9.4-x86.msi
+    x64: https://nodejs.org/dist/v8.9.4/node-v8.9.4-x64.msi
 
 2.  Download Checksums:
     
-    SHASUMS: https://nodejs.org/dist/v8.9.3/SHASUMS256.txt.asc
+    SHASUMS: https://nodejs.org/dist/v8.9.4/SHASUMS256.txt.asc
 
     OR 
     
@@ -17,8 +17,8 @@ in verifying that this package's contents are trustworthy.
     - Use powershell function 'Get-FileHash'
     - Use Chocolatey utility 'checksum.exe'
     - Using AU:
-        Get-RemoteChecksum https://nodejs.org/dist/v8.9.3/node-v8.9.3-x64.msi
+        Get-RemoteChecksum https://nodejs.org/dist/v8.9.4/node-v8.9.4-x64.msi
     
     
-    checksum32: 5F8E0E01879F273751DD1D0DA7DE44B4F32E65F62B5D3C373F54ABD8C6DB3F5A
-    checksum64: 68CDD5A021101A208D830DA016EEBB3A9DE5BA75E76D8D8D6E9332038F10F56A
+    checksum32: F9442188C2F66D167A0AC610DEE6D16E226BA28CA93F9569E0276268EB8F85DC
+    checksum64: 547689DA69BACADFEE619D208702B73698D14297BD5FEF5D80656897989E91B6

--- a/nodejs-lts/nodejs-lts.nuspec
+++ b/nodejs-lts/nodejs-lts.nuspec
@@ -14,7 +14,7 @@
     <licenseUrl>https://github.com/nodejs/node/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/nodejs/node</projectSourceUrl>
-    <docsUrl>https://nodejs.org/dist/latest-v6.x/docs/api/</docsUrl>
+    <docsUrl>https://nodejs.org/dist/latest-v8.x/docs/api/</docsUrl>
     <bugTrackerUrl>https://github.com/nodejs/node/issues</bugTrackerUrl>
     <tags>nodejs-lts nodejs lts node.js node admin npm javascript</tags>
     <summary>Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine</summary>

--- a/nodejs-lts/nodejs-lts.nuspec
+++ b/nodejs-lts/nodejs-lts.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>nodejs-lts</id>
-    <version>8.9.3</version>
+    <version>8.9.4</version>
     <packageSourceUrl>https://github.com/jtcmedia/chocolatey-packages/tree/master/nodejs-lts</packageSourceUrl>
     <owners>LudicrousByte</owners>
     <title>Node.js LTS (Install)</title>

--- a/nodejs-lts/nodejs-lts.nuspec
+++ b/nodejs-lts/nodejs-lts.nuspec
@@ -10,7 +10,7 @@
     <authors>Node.js Foundation</authors>
     <projectUrl>https://nodejs.org/</projectUrl>
     <iconUrl>http://cdn.rawgit.com/jtcmedia/chocolatey-packages/nodejs-lts-icon/icons/nodejs-lts.png</iconUrl>
-    <copyright>© 2017 Node.js Foundation</copyright>
+    <copyright>© 2018 Node.js Foundation</copyright>
     <licenseUrl>https://github.com/nodejs/node/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/nodejs/node</projectSourceUrl>


### PR DESCRIPTION
This includes updating the checksums accordingly as well as fixing the copyright year and docsUrl.