### PR TITLE
Point DS4Windows iconUrl to master

### DIFF
--- a/ds4windows/ds4windows.nuspec
+++ b/ds4windows/ds4windows.nuspec
@@ -12,7 +12,7 @@
     <copyright>Copyright (c) 2019 Travis Nickles</copyright>
     <licenseUrl>https://github.com/Ryochan7/DS4Windows/blob/jay/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <iconUrl>https://cdn.rawgit.com/jtcmedia/chocolatey-packages/ds4windows-icon/icons/ds4windows.png</iconUrl>
+    <iconUrl>https://cdn.rawgit.com/jtcmedia/chocolatey-packages/master/icons/ds4windows.png</iconUrl>
     <docsUrl>http://ds4windows.com/</docsUrl>
     <bugTrackerUrl>https://github.com/Ryochan7/DS4Windows/issues</bugTrackerUrl>
     <tags>ds4windows ps4 dualshock controller emulator foss</tags>


### PR DESCRIPTION
I was wondering why the DS4Windows icon didn't change in Chocolatey. Turns out the iconUrl was still pointing to the old `ds4windows-icon` tag.