### PR TITLE
Fix cura-lulzbot update script when filename ends with `win10-win32`

### DIFF
--- a/cura-lulzbot/update.ps1
+++ b/cura-lulzbot/update.ps1
@@ -21,6 +21,8 @@ function global:au_GetLatest {
 	
     if($version[0] -match '^lulzbot$') {
       $version = $version[1]
+    } elseif ($version[1] -match '^win10$') {
+        $version = $version[0]
     } else {
       $version = $version[0] + '.' + $version[1]
     }


### PR DESCRIPTION
LulzBot has been adding `-win10` to their filenames since version 3.6.30.