### PR TITLE
Added shim for prusa-gcodeviewer

### DIFF
--- a/prusaslicer/prusaslicer.nuspec
+++ b/prusaslicer/prusaslicer.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>prusaslicer</id>
-    <version>2.5.0.20220728-alpha3</version>
+    <version>2.5.0.20220808-alpha3</version>
     <packageSourceUrl>https://github.com/jtcmedia/chocolatey-packages/tree/master/prusaslicer</packageSourceUrl>
     <owners>LudicrousByte</owners>
     <title>PrusaSlicer</title>

--- a/prusaslicer/tools/chocolateyinstall.ps1
+++ b/prusaslicer/tools/chocolateyinstall.ps1
@@ -13,7 +13,7 @@ Get-ChocolateyUnzip @packageArgs
 $files = Get-ChildItem $toolsPath -Include *.exe -Recurse
 
 foreach ($file in $files) {
-  if (!($file.Name.Equals("prusa-slicer.exe"))) {
+  if (!($file.Name.Equals("prusa-slicer.exe") -or $file.Name.Equals("prusa-gcodeviewer.exe"))) {
     #generate an ignore file
     New-Item "$file.ignore" -type file -Force | Out-Null
   }


### PR DESCRIPTION
I missed a shim for the useful prusa-gcodeviewer which was unfortunately excluded.