### PR TITLE
Use Join-Path cmdlet for dot sourcing

### DIFF
--- a/arduino-cli/update.ps1
+++ b/arduino-cli/update.ps1
@@ -1,6 +1,5 @@
 import-module au
-. $([System.IO.Path]::Combine("..", 'helper-scripts', 'Get-GitHubLatestReleaseLinks.ps1'))
-
+. (Join-Path '..' 'helper-scripts' 'Get-GitHubLatestReleaseLinks.ps1')
 
 function global:au_SearchReplace {
     @{
@@ -20,7 +19,6 @@ function global:au_SearchReplace {
 }
 
 function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
-
 
 function global:au_GetLatest {
     $download_page = Get-GitHubLatestReleaseLinks -User "arduino" -Repository "arduino-cli"

--- a/argocd-cli/update.ps1
+++ b/argocd-cli/update.ps1
@@ -1,6 +1,5 @@
 import-module au
-. $([System.IO.Path]::Combine("..", 'helper-scripts', 'Get-GitHubLatestReleaseLinks.ps1'))
-
+. (Join-Path '..' 'helper-scripts' 'Get-GitHubLatestReleaseLinks.ps1')
 
 function global:au_SearchReplace {
     @{
@@ -16,8 +15,7 @@ function global:au_SearchReplace {
     }
 }
 
-function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix -FileNameBase 'argocd'}
-
+function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix -FileNameBase 'argocd' }
 
 function global:au_GetLatest {
     $download_page = Get-GitHubLatestReleaseLinks -User "argoproj" -Repository "argo-cd"

--- a/avisynthplus/update.ps1
+++ b/avisynthplus/update.ps1
@@ -1,6 +1,5 @@
 import-module au
-. $([System.IO.Path]::Combine("..", 'helper-scripts', 'Get-GitHubLatestReleaseLinks.ps1'))
-
+. (Join-Path '..' 'helper-scripts' 'Get-GitHubLatestReleaseLinks.ps1')
 
 function global:au_SearchReplace {
     @{

--- a/balena-cli/update.ps1
+++ b/balena-cli/update.ps1
@@ -1,6 +1,5 @@
 import-module au
-. $([System.IO.Path]::Combine("..", 'helper-scripts', 'Get-GitHubLatestReleaseLinks.ps1'))
-
+. (Join-Path '..' 'helper-scripts' 'Get-GitHubLatestReleaseLinks.ps1')
 
 function global:au_SearchReplace {
     @{

--- a/cypress/update.ps1
+++ b/cypress/update.ps1
@@ -1,6 +1,5 @@
 import-module au
-. $([System.IO.Path]::Combine("..", 'helper-scripts', 'Get-GitHubLatestReleaseLinks.ps1'))
-
+. (Join-Path '..' 'helper-scripts' 'Get-GitHubLatestReleaseLinks.ps1')
 
 function global:au_SearchReplace {
     @{

--- a/faas-cli/update.ps1
+++ b/faas-cli/update.ps1
@@ -1,6 +1,5 @@
 import-module au
-. $([System.IO.Path]::Combine("..", 'helper-scripts', 'Get-GitHubLatestReleaseLinks.ps1'))
-
+. (Join-Path '..' 'helper-scripts' 'Get-GitHubLatestReleaseLinks.ps1')
 
 function global:au_SearchReplace {
     @{

--- a/fs-uae/update.ps1
+++ b/fs-uae/update.ps1
@@ -1,6 +1,5 @@
 import-module au
-. $([System.IO.Path]::Combine("..", 'helper-scripts', 'Get-GitHubLatestReleaseLinks.ps1'))
-
+. (Join-Path '..' 'helper-scripts' 'Get-GitHubLatestReleaseLinks.ps1')
 
 function global:au_SearchReplace {
     @{

--- a/handbrake-cli/update.ps1
+++ b/handbrake-cli/update.ps1
@@ -1,6 +1,5 @@
 import-module au
-. $([System.IO.Path]::Combine("..", 'helper-scripts', 'Get-GitHubLatestReleaseLinks.ps1'))
-
+. (Join-Path '..' 'helper-scripts' 'Get-GitHubLatestReleaseLinks.ps1')
 
 function global:au_SearchReplace {
     @{

--- a/handbrake.install/update.ps1
+++ b/handbrake.install/update.ps1
@@ -1,5 +1,5 @@
 import-module au
-. $([System.IO.Path]::Combine("..", 'helper-scripts', 'Get-GitHubLatestReleaseLinks.ps1'))
+. (Join-Path '..' 'helper-scripts' 'Get-GitHubLatestReleaseLinks.ps1')
 
 $releases = 'https://github.com/HandBrake/HandBrake/releases/latest'
 

--- a/handbrake.portable/update.ps1
+++ b/handbrake.portable/update.ps1
@@ -1,6 +1,5 @@
 import-module au
-. $([System.IO.Path]::Combine("..", 'helper-scripts', 'Get-GitHubLatestReleaseLinks.ps1'))
-
+. (Join-Path '..' 'helper-scripts' 'Get-GitHubLatestReleaseLinks.ps1')
 
 function global:au_SearchReplace {
     @{

--- a/keepass-plugin-keepassnatmsg/update.ps1
+++ b/keepass-plugin-keepassnatmsg/update.ps1
@@ -1,6 +1,5 @@
 import-module au
-. $([System.IO.Path]::Combine("..", 'helper-scripts', 'Get-GitHubLatestReleaseLinks.ps1'))
-
+. (Join-Path '..' 'helper-scripts' 'Get-GitHubLatestReleaseLinks.ps1')
 
 function global:au_SearchReplace {
     @{

--- a/maptool/update.ps1
+++ b/maptool/update.ps1
@@ -1,6 +1,5 @@
 import-module au
-. $([System.IO.Path]::Combine("..", 'helper-scripts', 'Get-GitHubLatestReleaseLinks.ps1'))
-
+. (Join-Path '..' 'helper-scripts' 'Get-GitHubLatestReleaseLinks.ps1')
 
 function global:au_SearchReplace {
     @{

--- a/meshlab/update.ps1
+++ b/meshlab/update.ps1
@@ -1,6 +1,5 @@
 import-module au
-. $([System.IO.Path]::Combine("..", 'helper-scripts', 'Get-GitHubLatestReleaseLinks.ps1'))
-
+. (Join-Path '..' 'helper-scripts' 'Get-GitHubLatestReleaseLinks.ps1')
 
 function global:au_SearchReplace {
     @{
@@ -16,9 +15,7 @@ function global:au_SearchReplace {
     }
 }
 
-
 function global:au_BeforeUpdate { Get-RemoteFiles -Purge }
-
 
 function global:au_GetLatest {
     $download_page = Get-GitHubLatestReleaseLinks -User "cnr-isti-vclab" -Repository "meshlab"

--- a/nvidia-profile-inspector/update.ps1
+++ b/nvidia-profile-inspector/update.ps1
@@ -1,6 +1,5 @@
 import-module au
-. $([System.IO.Path]::Combine("..", 'helper-scripts', 'Get-GitHubLatestReleaseLinks.ps1'))
-
+. (Join-Path '..' 'helper-scripts' 'Get-GitHubLatestReleaseLinks.ps1')
 
 function global:au_SearchReplace {
     @{
@@ -17,7 +16,6 @@ function global:au_SearchReplace {
 }
 
 function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
-
 
 function global:au_GetLatest {
     $download_page = Get-GitHubLatestReleaseLinks -User "Orbmu2k" -Repository "nvidiaProfileInspector"

--- a/opentrack/update.ps1
+++ b/opentrack/update.ps1
@@ -1,6 +1,5 @@
 import-module au
-. $([System.IO.Path]::Combine("..", 'helper-scripts', 'Get-GitHubLatestReleaseLinks.ps1'))
-
+. (Join-Path '..' 'helper-scripts' 'Get-GitHubLatestReleaseLinks.ps1')
 
 function global:au_SearchReplace {
     @{

--- a/prusaslicer/update.ps1
+++ b/prusaslicer/update.ps1
@@ -1,6 +1,5 @@
 import-module au
-. $([System.IO.Path]::Combine("..", 'helper-scripts', 'Get-GitHubLatestReleaseLinks.ps1'))
-
+. (Join-Path '..' 'helper-scripts' 'Get-GitHubLatestReleaseLinks.ps1')
 
 function global:au_SearchReplace {
     @{
@@ -16,9 +15,7 @@ function global:au_SearchReplace {
     }
 }
 
-
 function global:au_BeforeUpdate { Get-RemoteFiles -Purge }
-
 
 function global:au_GetLatest {
     $download_page = Get-GitHubLatestReleaseLinks -User "prusa3d" -Repository "PrusaSlicer"

--- a/remix-desktop/update.ps1
+++ b/remix-desktop/update.ps1
@@ -1,6 +1,5 @@
 import-module au
-. $([System.IO.Path]::Combine("..", 'helper-scripts', 'Get-GitHubLatestReleaseLinks.ps1'))
-
+. (Join-Path '..' 'helper-scripts' 'Get-GitHubLatestReleaseLinks.ps1')
 
 function global:au_SearchReplace {
     @{
@@ -17,7 +16,6 @@ function global:au_SearchReplace {
 }
 
 function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
-
 
 function global:au_GetLatest {
     $download_page = Get-GitHubLatestReleaseLinks -User "ethereum" -Repository "remix-desktop"

--- a/staxrip/update.ps1
+++ b/staxrip/update.ps1
@@ -1,6 +1,5 @@
 import-module au
-. $([System.IO.Path]::Combine("..", 'helper-scripts', 'Get-GitHubLatestReleaseLinks.ps1'))
-
+. (Join-Path '..' 'helper-scripts' 'Get-GitHubLatestReleaseLinks.ps1')
 
 function global:au_SearchReplace {
     @{

--- a/t-rex/update.ps1
+++ b/t-rex/update.ps1
@@ -1,6 +1,5 @@
 import-module au
-. $([System.IO.Path]::Combine("..", 'helper-scripts', 'Get-GitHubLatestReleaseLinks.ps1'))
-
+. (Join-Path '..' 'helper-scripts' 'Get-GitHubLatestReleaseLinks.ps1')
 
 function global:au_SearchReplace {
     @{

--- a/uvtools/update.ps1
+++ b/uvtools/update.ps1
@@ -1,6 +1,5 @@
 import-module au
-. $([System.IO.Path]::Combine("..", 'helper-scripts', 'Get-GitHubLatestReleaseLinks.ps1'))
-
+. (Join-Path '..' 'helper-scripts' 'Get-GitHubLatestReleaseLinks.ps1')
 
 function global:au_SearchReplace {
     @{
@@ -17,7 +16,6 @@ function global:au_SearchReplace {
 }
 
 function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
-
 
 function global:au_GetLatest {
     $download_page = Get-GitHubLatestReleaseLinks -User "sn4k3" -Repository "UVtools"


### PR DESCRIPTION
Use **Join-Path** cmdlet instead of **System.IO.Path.Combine** for dot sourcing the **Get-GitHubLatestReleaseLinks.ps1** helper script.

This change keeps the update script more PowerShell native (i.e., without having to use .NET assemblies).