### PR TITLE
Update ZAP to 2.14 and remove OWASP references

### DIFF
--- a/zap/README.md
+++ b/zap/README.md
@@ -1,8 +1,8 @@
 
 
-# OWASP Zed Attack Proxy (ZAP)
+# Zed Attack Proxy (ZAP)
 
-The OWASP Zed Attack Proxy (ZAP) is one of the world’s most popular free security tools and is actively maintained by hundreds of international volunteers. It can help you automatically find security vulnerabilities in your web applications while you are developing and testing your applications. Its also a great tool for experienced pentesters to use for manual security testing.
+The Zed Attack Proxy (ZAP) is one of the world’s most popular free security tools and is actively maintained by hundreds of international volunteers. It can help you automatically find security vulnerabilities in your web applications while you are developing and testing your applications. Its also a great tool for experienced pentesters to use for manual security testing.
 
 ## Features
 
@@ -26,7 +26,7 @@ Some of ZAP's functionality:
 
 ## Package Note
 
-**ZAP 2.12 requires Java 11 or higher and that the JAVA_HOME environment variable is set**. You can install a Chocolatey Java Package or Java from Oracle. One suggestion is the [Temurin11jre](https://community.chocolatey.org/packages/Temurin11jre) package. Ensure you install it with the `FeatureJavaHome` parameter set.
+**ZAP 2.14 requires Java 11 or higher and that the JAVA_HOME environment variable is set**. You can install a Chocolatey Java Package or Java from Oracle. One suggestion is the [Temurin11jre](https://community.chocolatey.org/packages/Temurin11jre) package. Ensure you install it with the `FeatureJavaHome` parameter set.
 
 ## Maintainer's Note
 

--- a/zap/tools/chocolateyinstall.ps1
+++ b/zap/tools/chocolateyinstall.ps1
@@ -2,10 +2,10 @@
 
 $packageName    = 'zap'
 $toolsDir       = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url32          = 'https://github.com/zaproxy/zaproxy/releases/download/v2.12.0/ZAP_2_12_0_windows-x32.exe'
-$url64          = 'https://github.com/zaproxy/zaproxy/releases/download/v2.12.0/ZAP_2_12_0_windows.exe'
-$checksum32     = 'fa741469190fd7d29ed870682a614535082a0c403450707c1359e79fe0cd0813'
-$checksum64     = '2dc7236c076dff9d35782fb85dbcfea1c57a63eca26ded15807ef2f62a0dcfd5'
+$url32          = 'https://github.com/zaproxy/zaproxy/releases/download/v2.14.0/ZAP_2_14_0_windows-x32.exe'
+$url64          = 'https://github.com/zaproxy/zaproxy/releases/download/v2.14.0/ZAP_2_14_0_windows.exe'
+$checksum32     = '5dae52e27da12fba5115e40ebc0cd2da24f6d9ba91608a7b0b7b254984a0b798'
+$checksum64     = 'df49ffbd14cf82cde5ac06902615e40cbfce1576f866436366708c0845eb9ec6'
 $pf             = ''
 
 $packageArgs = @{
@@ -14,7 +14,7 @@ $packageArgs = @{
   fileType       = 'EXE'
   url            = $url32
   url64bit       = $url64
-  softwareName   = 'OWASP Zed Attack Proxy*'
+  softwareName   = 'Zed Attack Proxy*'
   checksum       = $checksum32
   checksumType   = 'sha256'
   checksum64     = $checksum64
@@ -32,11 +32,11 @@ if (Test-Path 'env:JAVA_HOME') {
     Install-ChocolateyPackage @packageArgs
     if ( Get-OSArchitectureWidth 32 ) { $pf = ' (x86)' }
     Install-ChocolateyShortcut `
-      -ShortcutFilePath "C:\Users\Public\Desktop\OWASP ZAP $($env:ChocolateyPackageVersion.SubString(0,6)).lnk" `
-      -TargetPath "C:\Program Files$pf\OWASP\Zed Attack Proxy\ZAP.bat" `
-      -WorkingDirectory "C:\Program Files$pf\OWASP\Zed Attack Proxy"
+      -ShortcutFilePath "C:\Users\Public\Desktop\ZAP $($env:ChocolateyPackageVersion.SubString(0,6)).lnk" `
+      -TargetPath "C:\Program Files$pf\ZAP\Zed Attack Proxy\ZAP.bat" `
+      -WorkingDirectory "C:\Program Files$pf\ZAP\Zed Attack Proxy"
   } else {
-    Write-Error "Java version is less than 11. ZAP 2.12 or greater requires Java 11."
+    Write-Error "Java version is less than 11. ZAP 2.14 or greater requires Java 11."
   }
 } else {
   Write-Error "JAVA_HOME isn't set. Ensure you set this environment variable to a Java 11+ installation."

--- a/zap/tools/chocolateyuninstall.ps1
+++ b/zap/tools/chocolateyuninstall.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop';
 
 $packageName = 'zap'
-$softwareName = 'OWASP Zed Attack Proxy*'
+$softwareName = 'Zed Attack Proxy*'
 $installerType = 'EXE' 
 $silentArgs = '-q'
 $validExitCodes = @(0)

--- a/zap/zap.nuspec
+++ b/zap/zap.nuspec
@@ -3,25 +3,25 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>zap</id>
-    <version>2.12.0.20221127</version>
+    <version>2.14.0.20231012</version>
     <packageSourceUrl>https://github.com/jtcmedia/chocolatey-packages/tree/master/zap</packageSourceUrl>
     <owners>LudicrousByte</owners>
-    <title>OWASP Zed Attack Proxy (ZAP) (Install)</title>
-    <authors>Simon Bennetts OWASP</authors>
+    <title>Zed Attack Proxy (ZAP) (Install)</title>
+    <authors>Simon Bennetts</authors>
     <projectUrl>https://www.zaproxy.org/</projectUrl>
     <iconUrl>https://rawcdn.githack.com/jtcmedia/chocolatey-packages/21dec8124d4ca81a4956465270b35386c95e4c25/icons/zap.png</iconUrl>
-    <copyright>Copyright © 2022 the ZAP Dev Team</copyright>
+    <copyright>Copyright © 2024 the ZAP Dev Team</copyright>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/zaproxy/zaproxy</projectSourceUrl>
     <docsUrl>https://www.zaproxy.org/docs/</docsUrl>
     <mailingListUrl>https://groups.google.com/g/zaproxy-users</mailingListUrl>
     <bugTrackerUrl>https://github.com/zaproxy/zaproxy/issues</bugTrackerUrl>
-    <tags>zap admin owasp security proxy attack web pentesting</tags>
+    <tags>zap admin dast security proxy attack web pentesting</tags>
     <summary>The Zed Attack Proxy (ZAP) is an easy to use integrated penetration testing tool for finding vulnerabilities in web applications.</summary>
-    <description><![CDATA[# OWASP Zed Attack Proxy (ZAP)
+    <description><![CDATA[# Zed Attack Proxy (ZAP)
 
-The OWASP Zed Attack Proxy (ZAP) is one of the world’s most popular free security tools and is actively maintained by hundreds of international volunteers. It can help you automatically find security vulnerabilities in your web applications while you are developing and testing your applications. Its also a great tool for experienced pentesters to use for manual security testing.
+The Zed Attack Proxy (ZAP) is one of the world’s most popular free security tools and is actively maintained by hundreds of international volunteers. It can help you automatically find security vulnerabilities in your web applications while you are developing and testing your applications. Its also a great tool for experienced pentesters to use for manual security testing.
 
 ## Features
 
@@ -45,13 +45,13 @@ Some of ZAP's functionality:
 
 ## Package Note
 
-**ZAP 2.12 requires Java 11 or higher and that the JAVA_HOME environment variable is set**. You can install a Chocolatey Java Package or Java from Oracle. One suggestion is the [Temurin11jre](https://community.chocolatey.org/packages/Temurin11jre) package. Ensure you install it with the `FeatureJavaHome` parameter set.
+**ZAP 2.14 requires Java 11 or higher and that the JAVA_HOME environment variable is set**. You can install a Chocolatey Java Package or Java from Oracle. One suggestion is the [Temurin11jre](https://community.chocolatey.org/packages/Temurin11jre) package. Ensure you install it with the `FeatureJavaHome` parameter set.
 
 ## Maintainer's Note
 
 I produce and maintain Chocolatey packages in my spare time, for free. If you use my packages, and appreciate the time and effort I put into making and maintaining them, please consider [making a small donation](https://www.buymeacoffee.com/jtcmedia). Thank-you!
 ]]></description>
-    <releaseNotes>https://www.zaproxy.org/docs/desktop/releases/2.12.0</releaseNotes>
+    <releaseNotes>https://www.zaproxy.org/docs/desktop/releases/2.14.0/</releaseNotes>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />


### PR DESCRIPTION
https://www.zaproxy.org/blog/2023-08-01-zap-is-joining-the-software-security-project/