### PR TITLE
Add v22 to list of Node LTS versions

### DIFF
--- a/nodejs-lts/update.ps1
+++ b/nodejs-lts/update.ps1
@@ -1,6 +1,6 @@
 import-module chocolatey-au
 
-$lts_versions = '20', '18'
+$lts_versions = '22', '20', '18'
 
 function global:au_SearchReplace {
     @{


### PR DESCRIPTION
Node 22 has become LTS (https://nodejs.org/en/about/previous-releases) and should be published with the nodejs-lts package